### PR TITLE
더 이상 group_by_length sampler를 사용하지 않습니다.

### DIFF
--- a/dataloader.py
+++ b/dataloader.py
@@ -20,7 +20,7 @@ class AudioDataLoader(torch.utils.data.DataLoader):
         audio_lengths = [s["input_values"].size(0) for s in batch]
         targets = [torch.as_tensor(s["input_ids"], dtype=torch.int32) for s in batch]
         target_lengths = [len(s["input_ids"]) for s in batch]
-        audio_lengths = torch.IntTensor(audio_lengths)
+        tensor_audio_lengths = torch.IntTensor(audio_lengths)
         target_lengths = torch.IntTensor(target_lengths)
 
         # input_ids: (,token)
@@ -38,9 +38,12 @@ class AudioDataLoader(torch.utils.data.DataLoader):
         assert self.n_mels == batch[0]["input_values"].size(-1), "config의 feature shape과 실제 데이터의 feature가 다름"
         for s in range(len(target_lengths)):
             assert text_lengths[s] == target_lengths[s] + 1, "prednet의 Input은 targets_lengts에 +1(blank)여야 합니다. 데이터 오류!"
+        input_audios = pad_sequence(input_audios, batch_first=True, padding_value=self.pad_token_id)
         input_texts = pad_sequence(input_texts, batch_first=True, padding_value=self.pad_token_id)
         targets = pad_sequence(targets, batch_first=True, padding_value=self.pad_token_id)
 
-        # input_texts, targets, audio_lengths, target_lengths: on_cuda
-        # input_audios, text_lengths : on_cpu or not tensor
-        return input_audios, audio_lengths, input_texts, text_lengths, targets, target_lengths
+        # input_audios, tensor_audio_lengths, input_texts, targets, audio_lengths, target_lengths: on_cuda
+        # audio_lengths, text_lengths : on_cpu or not tensor
+        # pack_pad를 진행하기위한 lengths계산은 무조건 CPU에서 동작해야하는데, rnntloss를 계산하기위한 lengths는 무조건 Tensor여야 한다.
+        # 여기서 Tensor로 집어넣으면 무조건 gpu로 가기때문에, .cpu() .cuda()로 옮겨다니면 오버헤드가 발생할 여지가 있으므로, 애시당초에 여러 버전의 lengths를 주기로 했다.
+        return input_audios, audio_lengths, tensor_audio_lengths, input_texts, text_lengths, targets, target_lengths

--- a/datamodule.py
+++ b/datamodule.py
@@ -9,6 +9,7 @@ from argparse import Namespace
 from datasets import Dataset
 from dataloader import AudioDataLoader
 
+# 저는 1 batch로만 테스트되어서 group_by_length sampler가 오히려 느리기만 합니다.
 # from transformers.trainer_pt_utils import DistributedLengthGroupedSampler
 
 WINDOWS = {
@@ -172,15 +173,6 @@ class RNNTransducerDataModule(pl.LightningDataModule):
                 shard_datasets.save_to_disk(os.path.join(target_dataset_dir, train_type, str(shard_idx)))
 
     def prepare_data(self):
-        # prepare에서는 병렬처리 복잡도를 낮추고, 혹은 병렬처리 시 데이터가 손상될 위협을 방지하기위해 단일 CPU 프로세스로만 진행이 됩니다. (다중노드에서 사용하려면, prepare_data_per_node를 참고)
-        # 따라서, prepare에서 class 변수에 특정 상태를 저장하지 마십시오. 단일 프로세스로만 진행되므로, 다른 프로세스에서 참고할 수 없습니다.
-
-        # 데이터를 다운받고, 토크나이즈하고, 파일 시스템에 저장하는 task를 수행하십시오.
-        # TODO: 개인적으로 궁금한게 Streaming으로 데이터를 다운로드받는 와중에 학습시킨다면, prepare_data는 pass되어야 할까요?
-
-        # 여기서 진행하는 작업은 전체 데이터셋을 기준으로 합니다. 꼭 한번에 전체를 해야할지 잘 고민하십시오.
-        # log mel spectrogram으로 변환하는게 마침 1회만 진행하면 되고, 있으면 무시되면 되서 여기에 딱 알맞는 Task입니다.
-        # 사실 더 명확하게 하려면, 여기서는 raw_audio의 datasets를 다운받는 정도의 Task만 진행하고, log mel spectrogram 변환은 setup에서 하는게 더 나을지도 모르겠습니다. (GPU가 더 빠르려나?)
         if self.hf_data_dirs:
             self.save_raw_to_logmelspect_datasets(self.hf_data_dirs, self.pl_data_dir, "train")
             self.save_raw_to_logmelspect_datasets(self.hf_data_dirs, self.pl_data_dir, "dev")
@@ -191,19 +183,12 @@ class RNNTransducerDataModule(pl.LightningDataModule):
             pass
 
     def setup(self, stage: str):
-        # prepare_data가 정상적으로 동작되면 호출됩니다. setup은 각 모든 GPU에서 호출됩니다.
-        # 사용 가능한 모든 데이터들에 대한 모든 프로세스의 setup은 1번만 진행되도록 보장되어있습니다. (병렬처리하더라도, 1 data 1 setup을 보장한다는 의미같음.)
-        # 분류할 개수를 세거나, vocab을 만들거나, train/val/test splits을 하거나, datasets를 만들(선언하)거나, transforms를 수행해야 하거나
-        # 각각의 split stage에 맞는 torch형 datasets를 구성합니다.
-        # 모든 데이터셋을 한번에 읽어올 필요가 없다면, stage를 pass하거나 None으로 정의하십시오. (아마 콜레터를 쓰거나, train, test step에서 하고싶을 수 있으니까?)
-        # stage must like {fit,validate,test,predict}
         if stage == "fit":
             self.train_datasets = get_concat_dataset([self.pl_data_dir], "train")
             self.train_datasets.set_format("torch", ["input_values", "input_ids"])
             self.val_datasets = get_concat_dataset([self.pl_data_dir], "dev")
             self.val_datasets.set_format("torch", ["input_values", "input_ids"])
 
-        # Assign test dataset for use in dataloader(s)
         if stage == "test":
             self.clean_datasets = get_concat_dataset([self.pl_data_dir], "eval_clean")
             self.clean_datasets.set_format("torch", ["input_values", "input_ids"])
@@ -211,14 +196,6 @@ class RNNTransducerDataModule(pl.LightningDataModule):
             self.other_datasets.set_format("torch", ["input_values", "input_ids"])
 
     def train_dataloader(self):
-        # setup에서 완성된 datasets를 여기서 사용하십시오. trainer의 fit() method가 사용합니다.
-        # smart batching not good for RNNTransducer
-        # train_sampler = DistributedLengthGroupedSampler(
-        #     batch_size=self.per_device_eval_batch_size,
-        #     dataset=self.train_datasets,
-        #     model_input_name="input_values",
-        #     lengths=self.train_datasets["audio_len"],
-        # )
         return AudioDataLoader(
             dataset=self.train_datasets,
             batch_size=self.per_device_train_batch_size,
@@ -230,13 +207,6 @@ class RNNTransducerDataModule(pl.LightningDataModule):
         )
 
     def val_dataloader(self):
-        # setup에서 완성된 datasets를 여기서 사용하십시오. trainer의 fit(), validate() method가 사용합니다.
-        # val_sampler = DistributedLengthGroupedSampler(
-        #     batch_size=self.per_device_eval_batch_size,
-        #     dataset=self.val_datasets,
-        #     model_input_name="input_values",
-        #     lengths=self.val_datasets["audio_len"],
-        # )
         return AudioDataLoader(
             dataset=self.val_datasets,
             batch_size=self.per_device_eval_batch_size,
@@ -248,19 +218,6 @@ class RNNTransducerDataModule(pl.LightningDataModule):
         )
 
     def test_dataloader(self):
-        # setup에서 완성된 datasets를 여기서 사용하십시오. trainer의 test() method가 사용합니다.
-        # clean_sampler = DistributedLengthGroupedSampler(
-        #     batch_size=self.per_device_eval_batch_size,
-        #     dataset=self.clean_datasets,
-        #     model_input_name="input_values",
-        #     lengths=self.clean_datasets["audio_len"],
-        # )
-        # other_sampler = DistributedLengthGroupedSampler(
-        #     batch_size=self.per_device_eval_batch_size,
-        #     dataset=self.other_datasets,
-        #     model_input_name="input_values",
-        #     lengths=self.other_datasets["audio_len"],
-        # )
         return [
             AudioDataLoader(
                 dataset=self.clean_datasets,

--- a/inference.py
+++ b/inference.py
@@ -7,7 +7,6 @@ from simple_parsing import ArgumentParser
 
 
 def main(hparams):
-    # map_location = {"cuda:1": "cuda:0"}
     # prednet_params, transnet_params, jointnet_params, args
     # prednet_params: dict, transnet_params: dict, jointnet_params: dict, args: Namespace
     datasets = get_concat_dataset(hparams.pl_data_dir, "eval_clean")
@@ -21,7 +20,6 @@ def main(hparams):
         args=hparams,
     )
     model.eval()
-    # logits = self.jointnet
     input_audios = [datasets[0]["input_values"]]
     input_audios = pack_sequence(input_audios)
     with torch.no_grad():

--- a/model.py
+++ b/model.py
@@ -6,7 +6,6 @@ from warprnnt_pytorch import RNNTLoss as Warp_RNNTLoss
 from torchaudio.transforms import RNNTLoss as Torch_RNNTLoss
 from torchmetrics import WordErrorRate, CharErrorRate
 from transformers import Wav2Vec2CTCTokenizer
-from torch.nn.utils.rnn import pack_sequence
 
 
 class RNNTransducer(pl.LightningModule):
@@ -18,8 +17,6 @@ class RNNTransducer(pl.LightningModule):
     the output symbols are the characters of the alphabet.
     """
 
-    # 호출순서
-    # datamodule setup 끝 -> configure_optimizers -> dataloader(collate_fn)
     def __init__(self, prednet_params: dict, transnet_params: dict, jointnet_params: dict, args: Namespace):
         super().__init__()
         self.save_hyperparameters(prednet_params, transnet_params, jointnet_params, args)
@@ -27,9 +24,7 @@ class RNNTransducer(pl.LightningModule):
         self.tokenizer = Wav2Vec2CTCTokenizer(vocab_file=args.vocab_path)
         self.blank_token_id = self.tokenizer.pad_token_id
         prednet_params["pad_token_id"] = self.tokenizer.pad_token_id
-        # 다른 Transducer 쓰고싶으면 여기서 En,Decoder만 변경해서 사용
         self.jointnet = JointNet(transnet_params, prednet_params, **jointnet_params)
-        # Joint Net의 repeat concat 때문에 발생하는 메모리 커지는 이슈를 조금이라도 쉽게 타개하기 위함.
         if args.precision == 16:
             # precision 16의 경우 GPU 할당이 2배 여유가 생기므로 그냥 싹다 GPU에서 수행
             compute_on_cpu = False
@@ -45,93 +40,45 @@ class RNNTransducer(pl.LightningModule):
 
         self.calc_wer = WordErrorRate(compute_on_cpu=compute_on_cpu)
         self.calc_cer = CharErrorRate(compute_on_cpu=compute_on_cpu)
-        # CTC 사용편의성이 좋은 HuggingFace Transformers를 활용하였습니다. (Tokenizer 만들기 귀찮...)
-        # Truncated Backpropagation Through Time (https://pytorch-lightning.readthedocs.io/en/stable/guides/data.html)
-        # Important: This property activates truncated backpropagation through time
-        # Setting this value to 2 splits the batch into sequences of size 2
-        # 배치들을 시간별로 자를 길이를 지정합니다. 자른만큼씩 역전파가 진행됩니다.
-        # 해당 기능을 사용하려면 무조건 batch_first True여야 합니다.
-        # batch의 split을 수정하려면, pytorch_lightning.core.module.LightningModule.tbptt_split_batch()를 재정의하세요.
-
         # !!!!!!!! bptt 미적용
-        # rnnt_loss를 사용하면 기본적으로 전체 타임 순서에 대한 reduction된 output이 나온다. (나는 -> 나는 밥을 -> 나는 밥을 먹었다 의 loss reduction)
-        # bptt를 사용하려면, '나는'일때 역전파 1번, '나는 밥을'일때 역전파 1번, '나는 밥을 먹었다' 일때 역전파 1번해서 각각 3번의 역전파를 시켜야하는데,
-        # 라이브러리를 쓰면서 활용하려면, input_lengths만큼 역전파가 진행되어야 해서, 실질적으로 optimizing step을 수동으로 돌려야할 것이다.
-        # 수동으로 돌리려면, 그 만큼 성능도 저하될테니, 논문 그대로의 구현체를 만들어야 할 것이다.
-        # RNNTloss github 소스를 보면, 내부에서 C로 trans_grad와 pred_grad를 다루는 부분이 있는데, bptt 형태로 알아서 적용해주나 싶기도 하다...?
-        # 자세한 사항은 README 참고
-        # self.truncated_bptt_steps = 1
+        # 확실하진 않지만, RNNTLoss에서 각 인디코더의 grad를 확인한 것으로, 각각 BPTT 하듯이 적용해주지 않을까 사료됨.
+        # self.truncated_bptt_steps = 5
 
-    def forward(self, input_audios, input_texts, text_lengths):
+    def forward(self, input_audios, audio_lengths, input_texts, text_lengths):
 
-        logits = self.jointnet(input_audios, input_texts, text_lengths)
+        logits = self.jointnet(input_audios, audio_lengths, input_texts, text_lengths)
         return logits
 
     def training_step(self, batch, batch_idx):
-        # batch: 실제 데이터
-        # batch_idx: TBPTT가 아닌 실제 step의 인덱스 1 step == 1 batch
-        # hiddens: TBPTT용 전달 데이터
-        """
-        If the following conditions are satisfied:
-        1) cudnn is enabled,
-        2) input data is on the GPU
-        3) input data has dtype torch.float16
-        4) V100 GPU is used,
-        5) input data is not in PackedSequence format persistent algorithm
-        can be selected to improve performance.
-        """
-        # input_texts, targets, audio_lengths, target_lengths: on_cuda
-        # input_audios, text_lengths : on_cpu or not tensor
-        input_audios, audio_lengths, input_texts, text_lengths, targets, target_lengths = batch
-
-        # tbptt 진행시, 긴 시퀀스의 chunk로 진행이 되므로 training_step은 실질적으로 200 seq에 100 step chunk시
-        # 1배치를 수행하기위해 2번의 training_step이 요구됩니다. (0~99, 100~199를 수행하기 위함)
-        # 하지만, 새로운 배치에서의 hiddens은 이전과 연결되면 안되며, 매우 똑똑하게도, 새로운 batch_idx의 스텝시작시에는 hiddens는 None으로 처리됩니다.
-        # 실험은 ./multi_network_tbptt_test.py로 해볼 수 있음.
-
-        input_audios = pack_sequence(input_audios)  # input_audio: list -> cuda
-        logits = self(input_audios, input_texts, text_lengths)  # text_lengths must list or cpu cuda (list)
-        loss = self.rnnt_loss(logits, targets, audio_lengths, target_lengths)
-
-        # sync_dist를 선언하는 것으로 ddp의 4장비에서 계산된 loss의 평균치를 async로 불러오도록 한다. (log할때만 집계됨)
-        # self.log("train_loss_step", loss, sync_dist=True)
-        # the training step must be updated to accept a ``hiddens`` argument
-        # hiddens are the hiddens from the previous truncated backprop step
-        return {"loss": loss}
-
-    def training_step_end(self, outputs):
-        # only use when  on dp
         assert not self.args.move_metrics_to_cpu, "DDP만을 지원하므로, cpu로 metric이동되면 gather가 동작하지 않습니다."
-        self.log("train_loss", outputs["loss"], sync_dist=True)
+        input_audios, audio_lengths, tensor_audio_lengths, input_texts, text_lengths, targets, target_lengths = batch
+
+        logits = self(input_audios, audio_lengths, input_texts, text_lengths)
+        loss = self.rnnt_loss(logits, targets, tensor_audio_lengths, target_lengths)
+
+        self.log("train_loss", loss, sync_dist=True)
 
     def validation_step(self, batch, batch_idx):
-        # validation에서의 tbptt는 필요없습니다. (역전파를 진행하지 않으므로)
-        # 때문에 한번의 valid step의 모든 seq가 들어가야 합니다.
-        input_audios, audio_lengths, input_texts, text_lengths, targets, target_lengths = batch
+        input_audios, audio_lengths, tensor_audio_lengths, input_texts, text_lengths, targets, target_lengths = batch
 
-        # pad를 채우지 않고, 바로 pack 시키는 전략을 취함. audio는 스마트배칭으로, sort를 다시 할 필요가 없음
-        input_audios = pack_sequence(input_audios)
         if self.args.val_on_cpu or self.args.precision > 16:
             audio_lengths = audio_lengths.cpu()
+            tensor_audio_lengths = tensor_audio_lengths.cpu()
             input_texts = input_texts.cpu()
             targets = targets.cpu()
             target_lengths = target_lengths.cpu()
             input_audios = input_audios.cpu()
             self.cpu()
+        logits = self(input_audios, audio_lengths, input_texts, text_lengths)
+        loss = self.rnnt_loss(logits, targets, tensor_audio_lengths, target_lengths)
 
-        logits = self(input_audios, input_texts, text_lengths)
-        loss = self.rnnt_loss(logits, targets, audio_lengths, target_lengths)
-
-        pred_tokens = self.jointnet.recognize(input_audios, self.blank_token_id)
+        pred_tokens = self.jointnet.recognize(input_audios, audio_lengths, self.blank_token_id)
         pred_texts = self.tokenizer.batch_decode(pred_tokens)
         label_texts = self.tokenizer.batch_decode(targets)
         return {"loss": loss, "pred_texts": pred_texts, "label_texts": label_texts}
 
     def validation_epoch_end(self, validation_step_outputs):
         assert not self.args.move_metrics_to_cpu, "DDP만을 지원하므로, cpu로 metric이동되면 gather가 동작하지 않습니다."
-        # torch lightning은 약간의 데이터로 초기에 sanity eval step을 수행하고, training step에 돌입합니다.
-        # 여기서도 기본적인 값은 찍어볼 수 있으므로, 1 에폭 간신히 돌려놓고 에러맞아서 멘붕오지말고 미리미리 체크하는 것도 좋겠네요
-        # https://github.com/Lightning-AI/lightning/issues/2295 (trainer의 num_sanity_val_steps 옵션으로 끌 수도 있긴 함.)
         if self.precision == 16:
             # float16의 경우 torch audio를 활용하는데, 그 경우 torch value가 튀어나옴.
             loss_mean = torch.tensor([x["loss"] for x in validation_step_outputs], device=self.device).mean()
@@ -145,8 +92,6 @@ class RNNTransducer(pl.LightningModule):
             labels.extend(output["label_texts"])
         wer = self.calc_wer(preds, labels)
         cer = self.calc_cer(preds, labels)
-        # torchmetrics를 사용하는 경우, DistributedSampler가 각각 장비에서 동작하는 것으로 발생할 수 있는 비동기 문제에서 자유로워진다. (https://torchmetrics.readthedocs.io/en/stable/)
-        # torchmetrics를 사용하지 않을경우, self.log(sync_dist) 등을 사용하여 따로 처리해줘야함. (https://github.com/Lightning-AI/lightning/discussions/6501)
         if not self.on_gpu:
             # 이 곳에 빠지는 경우는, val_on_cpu가 True인 경우여야만 한다. 혹은 precision이 16 이상임.
             # nccl의 경우, allreduce는 cuda에 있어야 정상동작하므로 cpu output을 cuda로 바꿈
@@ -178,25 +123,3 @@ class RNNTransducer(pl.LightningModule):
         )
         lr_scheduler = {"interval": "step", "scheduler": scheduler, "name": "AdamW"}
         return {"optimizer": optimizer, "lr_scheduler": lr_scheduler}
-
-    """ Do Not DELETE This Source
-    This Used past on lr_scheduler.
-    """
-    # @property
-    # def num_training_steps(self) -> int:
-    #     """Total training steps inferred from datamodule and devices."""
-    #     if self.trainer.max_steps > 0:
-    #         return self.trainer.max_steps
-
-    #     limit_batches = self.trainer.limit_train_batches
-    #     batches = len(self.trainer.datamodule.train_dataloader())
-    #     batches = min(batches, limit_batches) if isinstance(limit_batches, int) else int(limit_batches * batches)
-
-    #     num_devices = max(1, self.trainer.num_devices)
-
-    #     effective_accum = self.trainer.accumulate_grad_batches * num_devices
-    #     return (batches // effective_accum) * self.trainer.max_epochs
-
-    # @property
-    # def steps_per_epoch(self) -> int:
-    #     return self.num_training_steps // self.trainer.max_epochs

--- a/model.py
+++ b/model.py
@@ -57,6 +57,7 @@ class RNNTransducer(pl.LightningModule):
         loss = self.rnnt_loss(logits, targets, tensor_audio_lengths, target_lengths)
 
         self.log("train_loss", loss, sync_dist=True)
+        return {"loss": loss}
 
     def validation_step(self, batch, batch_idx):
         input_audios, audio_lengths, tensor_audio_lengths, input_texts, text_lengths, targets, target_lengths = batch

--- a/networks/transducer.py
+++ b/networks/transducer.py
@@ -86,7 +86,9 @@ class JointNet(nn.Module):
 
         return outputs
 
-    def forward(self, input_audios: Tensor, input_texts: Tensor, text_lengths: Tensor) -> Tensor:
+    def forward(
+        self, input_audios: Tensor, audio_lengths: Tensor, input_texts: Tensor, text_lengths: Tensor
+    ) -> Tensor:
         """
         Forward propagate a `inputs` and `targets` pair for training.
 
@@ -101,7 +103,7 @@ class JointNet(nn.Module):
             * predictions (torch.FloatTensor): Result of model predictions.
         """
         # Use for inference only (separate from training_step)
-        enc_state = self.encoder(input_audios)
+        enc_state = self.encoder(input_audios, audio_lengths)
         dec_state, _ = self.decoder(input_texts, text_lengths)
         outputs = self.joint(enc_state, dec_state)
         return outputs
@@ -134,7 +136,7 @@ class JointNet(nn.Module):
         return torch.LongTensor(pred_tokens)
 
     @torch.no_grad()
-    def recognize(self, inputs: Tensor, blank_token_id: int) -> Tensor:
+    def recognize(self, inputs: Tensor, inputs_lengths: Tensor, blank_token_id: int) -> Tensor:
         """
         Recognize input speech. This method consists of the forward of the encoder and the decode() of the decoder.
 
@@ -147,7 +149,7 @@ class JointNet(nn.Module):
             * predictions (torch.FloatTensor): Result of model predictions.
         """
         outputs = list()
-        encoder_outputs = self.encoder(inputs)
+        encoder_outputs = self.encoder(inputs, inputs_lengths)
         max_length = encoder_outputs.size(1)
 
         for encoder_output in encoder_outputs:

--- a/train.py
+++ b/train.py
@@ -16,17 +16,10 @@ def main(hparams):
     setproctitle("bart_online_stt")
     pl.seed_everything(hparams.seed)
 
-    # DataModule의 prepare_data가 Main CPU에서만 동작하므로, 나머지 컴퓨팅 대상은 대기상태에 들어간다.
-    # torch.distributed.init_process_group의 timeout은 30분으로, 대기를 30분 이상하면 자동으로 종료된다.
-    # 때문에 대용량 Data는 절대로 완성되지 않을 경우가 존재하는데, 따라서 임시적으로 해당 파라미터만 조절한다.
-    # Trainer의 초기화가 from_argparse_args에서 hparams의 dict key, value 쌍으로 이루어지므로, 이렇게 구동하여도 문제는 없다. (개발자 가이드에도 제안되는 방법임)
     model_config_dict = read_json(hparams.model_config)["model"]
     data_config_dict = read_json(hparams.model_config)["data"]
 
     RNNT_datamodule = RNNTransducerDataModule(data_config_dict, hparams)
-    # (원문이 재밌어서 그대로 따옴) There are no .cuda() or .to(device) calls required. Lightning does these for you.
-    # DDP를 사용한다면, distributed sampler를 default로 선언하여 사용하게 해줍니다. 필요시 재정의도 가능합니다.
-    # torch.nn.Module 그대로이며, 추가된 사항만 있습니다. 찾아서 즐기세요!
     model = RNNTransducer(
         model_config_dict["prednet"], model_config_dict["transnet"], model_config_dict["jointnet"], hparams
     )
@@ -45,7 +38,12 @@ def main(hparams):
     lr_monitor = LearningRateMonitor(logging_interval="step")
     hparams.callbacks = [checkpoint_callback, lr_monitor]
 
+    # DataModule의 prepare_data가 Main CPU에서만 동작하므로, 나머지 컴퓨팅 대상은 대기상태에 들어간다.
+    # torch.distributed.init_process_group의 timeout은 30분으로, 대기를 30분 이상하면 자동으로 종료된다.
+    # 때문에 대용량 Data는 절대로 완성되지 않을 경우가 존재하는데, 따라서 임시적으로 해당 파라미터만 조절한다.
+    # Trainer의 초기화가 from_argparse_args에서 hparams의 dict key, value 쌍으로 이루어지므로, 이렇게 구동하여도 문제는 없다. (개발자 가이드에도 제안되는 방법임)
     hparams.strategy = DDPStrategy(timeout=timedelta(days=30))
+
     trainer = pl.Trainer.from_argparse_args(hparams)
     trainer.fit(model, datamodule=RNNT_datamodule)
     checkpoint_callback.best_model_path

--- a/utils/lightningmodule_args.py
+++ b/utils/lightningmodule_args.py
@@ -19,8 +19,9 @@ class LightningModuleArguments:
     learning_rate: float = 0.001
     warmup_ratio: float = 0.2
     max_lr: float = 0.01
-    final_div_factor: int = 1e4
+    final_div_factor: int = 1e4  # (max_lr/div_factor)*final_div_factor is final lr
     weight_decay: float = 0.0001
     val_on_cpu: bool = False
     seed: int = None
     local_rank: int = None
+    div_factor: int = 25  # initial_lr = max_lr/div_factor


### PR DESCRIPTION
그에 따라 pack_pad 로직 변화와, sort 기준을 다시 정의했고, 파라미터를 몇개 추가했으며,
lengths가 pack_pad에서는 cpu, loss 계산에서는 gpu로 사용되기때문에
dataloader에서 한꺼번에 그냥 다 만들어서 던져줍니다.
.cpu(), .cuda() 오버헤드 발생할까봐 그렇게 처리하였습니다.